### PR TITLE
Fix ApiClient's Request() function to read all response chunks

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -110,8 +111,13 @@ func (d *ApiClient) Request(method string, params interface{}) ([]byte, error) {
 		return []byte{}, err
 	}
 
-	buf := make([]byte, resp.ContentLength)
-	resp.Body.Read(buf)
+	defer resp.Body.Close()
+
+	buf, err := io.ReadAll(resp.Body)
+	if err != nil && err != io.EOF {
+		return []byte{}, err
+	}
+
 	decrypted, err := d.cipher.Decrypt(seq, buf)
 	if err != nil {
 		return []byte{}, err


### PR DESCRIPTION
Hi there, thanks for this great API! I've noticed one issue recently when pulling data from a H100 hub, which  came back partially and had garbled parts at the end. Turned out that client.go's Request() function calls Read() on the HTTP response with a buffer of length ContentLength, but this will only read the first response chunk, of which there might be more, depending on various network parameters.
This patch uses ReadAll() instead which gobbles up all chunks. Would be great if you could review and apply it!